### PR TITLE
Removing Social Link

### DIFF
--- a/Resume.html
+++ b/Resume.html
@@ -12,7 +12,6 @@
     <h3><b>Email :</b> goodkunal723@gmail.com</h3>
     <h3><b>Social :</b> 
         <a href="https:\\www.linkedin.com/in/kunal-gupta-775b9b1a0">LinkedIn</a>
-        <a href="https:\\www.linkedin.com/in/kunal-gupta-775b9b1a0">FaceBook</a>
     </h3>
     <h3>West Delhi, India</h3>
     <hr>


### PR DESCRIPTION
Removing the Facebook social Link as it links to LinkedIn Profile not to the Facebook one.